### PR TITLE
generate: use exponential random search for seed

### DIFF
--- a/Src/CommandLine.cs
+++ b/Src/CommandLine.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Math;
 using System.Reflection;
 using KyudosudokuWebsite.Database;
 using RT.CommandLine;
@@ -59,7 +60,7 @@ namespace KyudosudokuWebsite
 
                 // Choose a random number for a new puzzle
                 while (db.Puzzles.Any(p => p.PuzzleID == newPuzzleId))
-                    newPuzzleId += Rnd.Next(0, 1000);
+                    newPuzzleId += Rnd.Next(0, Math.Max(1000, newPuzzleId));
             }
             Console.WriteLine($"Generating puzzle #{newPuzzleId}");
             var start = DateTime.UtcNow;


### PR DESCRIPTION
A linear increase in identifier will, over time, become more expensive in database queries and time as the seed space is exhausted.
By using the failed seed as the upper bound, the number of existence hits will grow with the logarithm of the database size instead of proportional to the database size.

Note that this is not a practical performance concern: this code runs in a batch job, and actually generating the puzzle is much more expensive. This change is intended to spread knowledge of exponential backoff techniques.